### PR TITLE
Add error handling for empty and incomplete LLM responses

### DIFF
--- a/src/gitstory/__main__.py
+++ b/src/gitstory/__main__.py
@@ -56,6 +56,38 @@ def run(repo_path, branch, since, until):
         summarizer = AISummarizer(api_key=api_key)
         result = summarizer.summarize(parsed_data)
 
+        # Check for errors before displaying
+        if result.get("error"):
+            error_msg = result["error"]
+            click.echo("❌ Error generating summary", err=True)
+
+            # Provide specific, actionable error messages
+            if "empty" in error_msg.lower() or "no candidates" in error_msg.lower():
+                click.echo(
+                    "💡 The AI returned an empty response after 3 attempts.", err=True
+                )
+                click.echo(
+                    "   This might be temporary. Please try again in a few moments.",
+                    err=True,
+                )
+            elif "incomplete" in error_msg.lower() or "end marker" in error_msg.lower():
+                click.echo(
+                    "💡 The AI response was incomplete after 3 attempts.", err=True
+                )
+                click.echo("   This might be due to:", err=True)
+                click.echo("   - Network interruption", err=True)
+                click.echo("   - API timeout", err=True)
+                click.echo("   Please try again.", err=True)
+            elif "rate limit" in error_msg.lower():
+                click.echo(
+                    "💡 API rate limit exceeded. Please wait a few minutes and try again.",
+                    err=True,
+                )
+            else:
+                click.echo(f"   Details: {error_msg}", err=True)
+
+            sys.exit(1)
+
         # Step 4: Display summary in terminal
         click.echo("✅ Summary generation complete!")
         click.echo("\n" + "=" * 60)
@@ -102,11 +134,38 @@ def dashboard(repo_path):
         from gemini_ai import AISummarizer
 
         summarizer = AISummarizer(api_key=api_key)
-        result = summarizer.summarize(parsed_data)
+        result = summarizer.summarize(parsed_data, output_format="dashboard")
 
-        # Check for errors
-        if not result:
+        # Check for errors before generating dashboard
+        if result.get("error"):
+            error_msg = result["error"]
             click.echo("❌ Error generating summary", err=True)
+
+            # Provide specific, actionable error messages
+            if "empty" in error_msg.lower() or "no candidates" in error_msg.lower():
+                click.echo(
+                    "💡 The AI returned an empty response after 3 attempts.", err=True
+                )
+                click.echo(
+                    "   This might be temporary. Please try again in a few moments.",
+                    err=True,
+                )
+            elif "incomplete" in error_msg.lower() or "end marker" in error_msg.lower():
+                click.echo(
+                    "💡 The AI response was incomplete after 3 attempts.", err=True
+                )
+                click.echo("   This might be due to:", err=True)
+                click.echo("   - Network interruption", err=True)
+                click.echo("   - API timeout", err=True)
+                click.echo("   Please try again.", err=True)
+            elif "rate limit" in error_msg.lower():
+                click.echo(
+                    "💡 API rate limit exceeded. Please wait a few minutes and try again.",
+                    err=True,
+                )
+            else:
+                click.echo(f"   Details: {error_msg}", err=True)
+
             sys.exit(1)
 
         # Step 4: Display results on Visualization Dashboard
@@ -116,39 +175,16 @@ def dashboard(repo_path):
             repo_data=parsed_data,
             ai_summary=result,
             output_file="dashboard.html",
-            repo_path=repo_path
+            repo_path=repo_path,
         )
-        click.echo("Dashboard saved!")
+        click.echo("✅ Dashboard saved!")
+
+        return "Dashboard saved!"
 
     except Exception as e:
-        click.echo("❌ Error generating summary", err=True)
+        click.echo("❌ Error generating dashboard", err=True)
         click.echo(f"Error: {e}")
         sys.exit(1)
-        parser = RepoParser(branch="temporary branch information")
-        parsed_data = parser.parse()
-
-        # Step 3: Generate AI summary
-        click.echo("🤖 Generating AI summary...")
-        from gemini_ai import AISummarizer
-
-        summarizer = AISummarizer(api_key=api_key)
-        result = summarizer.summarize(parsed_data)
-        # Reads the JSON format + returns only the result
-
-        # Check for errors
-        if not result:
-            click.echo("❌ Error generating summary", err=True)
-            sys.exit(1)
-
-        # Step 4: Display results on Visualization Dashboard
-        from visual_dashboard.dashboard_generator import generate_dashboard
-
-        generate_dashboard(
-            repo_data=parsed_data,
-            ai_summary=result,
-            output_file="dashboard.html",
-        )
-        return "Dashboard saved!"
 
 
 @cli.command("since", short_help="Generate a summary starting from a date MM-DD-YYYY")

--- a/src/gitstory/gemini_ai/prompt_engine.py
+++ b/src/gitstory/gemini_ai/prompt_engine.py
@@ -31,6 +31,8 @@ FORMAT:
 
 ## Activity Breakdown
 [Brief stats about commit types and contributors]
+
+IMPORTANT: End your summary with [END-SUMMARY] on a new line to indicate completion.
 """
 
     DASHBOARD_SYSTEM_PROMPT = """You are a senior software engineer creating a detailed code history report.
@@ -64,6 +66,8 @@ FORMAT:
 
 ## Recent Activity
 [What's been happening lately]
+
+IMPORTANT: End your summary with [END-SUMMARY] on a new line to indicate completion.
 """
 
     def build_prompt(self, parsed_data: Dict, output_format: str) -> str:

--- a/src/gitstory/gemini_ai/response_handler.py
+++ b/src/gitstory/gemini_ai/response_handler.py
@@ -30,6 +30,22 @@ class ResponseHandler:
             raise ValueError(f"Invalid API response format: {error}") from error
 
         content = self._clean_content(content)
+
+        # Validate content is not empty or too short
+        if not content or len(content.strip()) < 20:
+            raise ValueError(
+                "Received empty or very short content from API (possible incomplete response)"
+            )
+
+        # Validate end marker exists
+        if "[END-SUMMARY]" not in content:
+            raise ValueError(
+                "Incomplete response: missing [END-SUMMARY] marker. The response may have been cut off."
+            )
+
+        # Remove the end marker before returning
+        content = content.replace("[END-SUMMARY]", "").strip()
+
         return (
             self._format_for_cli(content)
             if output_format == "cli"

--- a/src/gitstory/gemini_ai/summarizer.py
+++ b/src/gitstory/gemini_ai/summarizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any, Dict
 
 from .llm_client import LLMClient, SummarizationError
@@ -11,6 +12,9 @@ from .response_handler import ResponseHandler
 
 class AISummarizer:
     """Main entry point for transforming parsed repository data into narratives."""
+
+    MAX_RETRY_ATTEMPTS = 3
+    RETRY_DELAY_SECONDS = 5
 
     def __init__(self, api_key: str, model: str = "gemini-2.5-pro") -> None:
         self.client = LLMClient(api_key, model)
@@ -24,47 +28,77 @@ class AISummarizer:
         output_format: str = "cli",
         temperature: float = 0.7,
     ) -> Dict[str, Any]:
-        """Generate an AI summary for the provided parsed repository data."""
+        """Generate an AI summary for the provided parsed repository data with retry logic."""
         prompt = self.prompt_engine.build_prompt(parsed_data, output_format)
 
-        raw_response = None
-        summary_text = None
-        tokens_used = 0
-        error_msg = None
-        api_error = None
-        try:
-            raw_response = self.client.generate(prompt, temperature=temperature)
-        except SummarizationError as error:
-            api_error = str(error)
-        except Exception as error:
-            api_error = str(error)
-
-        # Always call process, even for invalid response, to satisfy test expectations
-        try:
-            summary_text = self.response_handler.process(raw_response, output_format)
-            tokens_used = self.response_handler.get_token_usage(raw_response)
-        except Exception as error:
-            error_msg = self.response_handler.extract_error_message(raw_response or {}) or str(error)
+        # Retry loop for handling transient failures
+        for attempt in range(1, self.MAX_RETRY_ATTEMPTS + 1):
+            raw_response = None
             summary_text = None
             tokens_used = 0
+            error_msg = None
+            api_error = None
 
-        # Prefer API error if present
-        final_error = api_error or error_msg
+            try:
+                # Step 1: Call LLM API (with built-in retries for API-level issues)
+                raw_response = self.client.generate(prompt, temperature=temperature)
 
-        # If there was an API error, return empty metadata as expected by tests
-        if final_error:
-            return {"summary": None, "metadata": {}, "error": final_error}
+                # Step 2: Process and validate response (checks for end marker, content quality)
+                summary_text = self.response_handler.process(
+                    raw_response, output_format
+                )
+                tokens_used = self.response_handler.get_token_usage(raw_response)
 
-        result = {
-            "summary": summary_text,
-            "metadata": {
-                "model": self.client.model,
-                "tokens_used": tokens_used,
-                "commits_analyzed": parsed_data.get("stats", {}).get("total_commits", 0),
-            },
-            "error": None,
-        }
-        return result
+                # Success! Return the result
+                return {
+                    "summary": summary_text,
+                    "metadata": {
+                        "model": self.client.model,
+                        "tokens_used": tokens_used,
+                        "commits_analyzed": parsed_data.get("stats", {}).get(
+                            "total_commits", 0
+                        ),
+                    },
+                    "error": None,
+                }
+
+            except SummarizationError as error:
+                # API-level errors (already retried in llm_client, don't retry again)
+                api_error = str(error)
+                break  # Exit retry loop, return error below
+
+            except ValueError as error:
+                # Content validation errors (empty, incomplete, missing end marker)
+                error_msg = str(error)
+                error_lower = error_msg.lower()
+
+                # Check if this is a retryable content error
+                is_retryable = (
+                    "incomplete" in error_lower
+                    or "empty" in error_lower
+                    or "end marker" in error_lower
+                    or "short content" in error_lower
+                )
+
+                if is_retryable and attempt < self.MAX_RETRY_ATTEMPTS:
+                    # Retry: wait and try again
+                    time.sleep(self.RETRY_DELAY_SECONDS)
+                    continue
+                else:
+                    # Not retryable or max attempts reached
+                    break
+
+            except Exception as error:
+                # Unexpected errors - don't retry
+                error_msg = self.response_handler.extract_error_message(
+                    raw_response or {}
+                ) or str(error)
+                break
+
+        # If we get here, all retries failed or encountered a non-retryable error
+        final_error = api_error or error_msg or "Unknown error during summarization"
+
+        return {"summary": None, "metadata": {}, "error": final_error}
 
     @staticmethod
     def _build_error_result(message: str) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,6 +310,95 @@ def mock_gemini_error_response():
 
 
 @pytest.fixture
+def mock_gemini_empty_json_response():
+    """
+    Returns an empty JSON response from Gemini API.
+
+    Simulates the case where the API returns an empty dictionary.
+    """
+    return {}
+
+
+@pytest.fixture
+def mock_gemini_empty_candidates_response():
+    """
+    Returns a Gemini API response with empty candidates array.
+
+    Simulates the case where the API returns valid JSON structure but no candidates.
+    """
+    return {"candidates": []}
+
+
+@pytest.fixture
+def mock_gemini_empty_text_response():
+    """
+    Returns a Gemini API response with empty text content.
+
+    Simulates the case where the API returns valid structure but empty text.
+    """
+    return {
+        "candidates": [{"content": {"parts": [{"text": ""}]}}],
+        "usageMetadata": {
+            "totalTokenCount": 10,
+        },
+    }
+
+
+@pytest.fixture
+def mock_gemini_incomplete_response():
+    """
+    Returns a Gemini API response with incomplete text (no end marker).
+
+    Simulates the case where the response is cut off before completion.
+    """
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "This is an incomplete summary that was cut off mid-sentence and doesn't have..."
+                        }
+                    ]
+                }
+            }
+        ],
+        "usageMetadata": {
+            "totalTokenCount": 100,
+        },
+    }
+
+
+@pytest.fixture
+def mock_gemini_complete_response_with_marker():
+    """
+    Returns a Gemini API response with complete text including end marker.
+
+    Simulates a successful response with the [END-SUMMARY] marker.
+    """
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "This is a complete summary of the repository changes. "
+                            "The team has made significant progress with new features, "
+                            "bug fixes, and improvements to code quality.\n\n[END-SUMMARY]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 500,
+            "candidatesTokenCount": 150,
+            "totalTokenCount": 650,
+        },
+    }
+
+
+@pytest.fixture
 def temp_output_dir(tmp_path):
     """
     Creates a temporary output directory for testing file operations.


### PR DESCRIPTION
## Problem

Gemini API occasionally returns empty or incomplete responses, causing confusing errors with no retry mechanism.

## Solution

Multi-layer validation with intelligent retry logic:

### End Marker System
- Prompts now instruct LLM to end responses with `[END-SUMMARY]`
- Responses without marker are detected as incomplete
- Marker is stripped from final output

### Validation & Retry

**llm_client.py**: Validates JSON structure, retries empty/malformed responses (3 attempts)

**response_handler.py**: Validates content length and end marker presence

**summarizer.py**: Retries content failures (3 attempts), skips retrying API errors

**__main__.py**: Displays specific error messages (empty, incomplete, rate limit)

## Changes

- `prompt_engine.py` - Added end marker instruction
- `llm_client.py` - Added validation, increased token limit to 4000, timeout to 60s
- `response_handler.py` - Added end marker validation
- `summarizer.py` - Added retry loop
- `__main__.py` - Improved error messages
- Tests: 5 new fixtures, 20 new tests, all 227 passing

## Testing

- ✅ Unit tests pass
- ✅ Real API tests on nano-vllm and gitstory repos
- ✅ Retry logic verified
- ✅ End marker flow verified

## Breaking Changes

None.